### PR TITLE
Remove spaces in `<ins>` statement.

### DIFF
--- a/resources/js/richvariables.js
+++ b/resources/js/richvariables.js
@@ -24,7 +24,7 @@ RedactorPlugins.richvariables = function() {
                 dropdown[key] = {
                     title: menuItem.title,
                     func: function(buttonName) {
-                        this.insert.raw('<ins> ' + menuItem.text + ' </ins>');
+                        this.insert.raw('<ins>' + menuItem.text + '</ins>');
                     },
                 };
             });


### PR DESCRIPTION
Removed spaces in `<ins>` tags as these were causing extra spacing to appear when inserted rich variable was immediately preceded or followed by punctuation.